### PR TITLE
Allocate new byte slice to prevent .netrc corruption

### DIFF
--- a/netrc/netrc.go
+++ b/netrc/netrc.go
@@ -219,6 +219,16 @@ func (m *Machine) UpdatePassword(newpass string) {
 	updateTokenValue(m.passtoken, newpass)
 }
 
+// TryUpdatePassword sets the password for the Machine m. Returns an error rather than panic
+func (m *Machine) TryUpdatePassword(newpass string) error {
+	m.Password = newpass
+	if m.passtoken == nil {
+		return fmt.Errorf(".netrc is corrupt - %s has a missing or invalid password token", m.Name)
+	}
+	updateTokenValue(m.passtoken, newpass)
+	return nil
+}
+
 // UpdateLogin sets the login for the Machine m.
 func (m *Machine) UpdateLogin(newlogin string) {
 	m.Login = newlogin

--- a/netrc/netrc.go
+++ b/netrc/netrc.go
@@ -361,6 +361,13 @@ func newToken(rawb []byte) (*token, error) {
 func scanValue(scanner *bufio.Scanner, pos int) ([]byte, string, int, error) {
 	if scanner.Scan() {
 		raw := scanner.Bytes()
+
+		// Future calls to scanner.Bytes() will overwrite the
+		// value of rawb, so make a copy before assigning
+		b := make([]byte, len(raw), len(raw))
+		copy(b, raw)
+		raw = b
+
 		pos += bytes.Count(raw, []byte{'\n'})
 		return raw, strings.TrimSpace(string(raw)), pos, nil
 	}
@@ -391,6 +398,13 @@ func parse(r io.Reader, pos int) (*Netrc, error) {
 			break
 		}
 		pos += bytes.Count(rawb, []byte{'\n'})
+
+		// Future calls to scanner.Bytes() will overwrite the
+		// value of rawb, so make a copy before assigning
+		b := make([]byte, len(rawb), len(rawb))
+		copy(b, rawb)
+		rawb = b
+
 		t, err = newToken(rawb)
 		if err != nil {
 			if currentMacro == nil {

--- a/netrc/netrc.go
+++ b/netrc/netrc.go
@@ -213,6 +213,9 @@ func (m *Machine) IsDefault() bool {
 // UpdatePassword sets the password for the Machine m.
 func (m *Machine) UpdatePassword(newpass string) {
 	m.Password = newpass
+	if m.passtoken == nil {
+		panic(fmt.Sprintf(".netrc is corrupt - %s has a missing or invalid password token", m.Name))
+	}
 	updateTokenValue(m.passtoken, newpass)
 }
 

--- a/netrc/netrc_test.go
+++ b/netrc/netrc_test.go
@@ -605,3 +605,17 @@ func TestMissingPassword(t *testing.T) {
 	m.UpdateLogin("joeschmoe2")
 	m.UpdatePassword("TOKEN2")
 }
+
+func TestMissingPasswordErr(t *testing.T) {
+	b := "machine github.com\n  login joeschmoe\n  \n"
+	nrc, err := Parse(strings.NewReader(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := nrc.FindMachine("github.com")
+	m.UpdateLogin("joeschmoe2")
+	err = m.TryUpdatePassword("TOKEN2")
+	if err == nil {
+		t.Errorf("Expected a panic (.netrc is corrupt - github.com has a missing or invalid password token)")
+	}
+}

--- a/netrc/netrc_test.go
+++ b/netrc/netrc_test.go
@@ -588,3 +588,20 @@ func TestLargeFile(t *testing.T) {
 		t.Log(string(body))
 	}
 }
+
+func TestMissingPassword(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected a panic (.netrc is corrupt - github.com has a missing or invalid password token)")
+		}
+	}()
+
+	b := "machine github.com\n  login joeschmoe\n  \n"
+	nrc, err := Parse(strings.NewReader(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := nrc.FindMachine("github.com")
+	m.UpdateLogin("joeschmoe2")
+	m.UpdatePassword("TOKEN2")
+}

--- a/netrc/netrc_test.go
+++ b/netrc/netrc_test.go
@@ -567,3 +567,24 @@ func netrcReader(filename string, t *testing.T) io.Reader {
 	}
 	return bytes.NewReader(b)
 }
+
+func TestLargeFile(t *testing.T) {
+	b := ""
+	for i := 0; i < 50; i++ {
+		b += "machine github.com\n  login joeschmoe\n  password TOKEN\n"
+	}
+	b += "machine fail\n  login fail\n  password FAIL"
+
+	nrc, err := Parse(strings.NewReader(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := nrc.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != b {
+		t.Errorf("Parsed netrc and marshalled netrc are not equal")
+		t.Log(string(body))
+	}
+}


### PR DESCRIPTION
I've run into an issue where reading my .netrc file using this library and writing it back out corrupts the file - overwriting the first few bytes of the file with one of the later tokens .  After some troubleshooting, I narrowed it down to affecting large files, and finally to scanner.Bytes() re-using a buffer that was returned.

>The underlying array may point to data that will be overwritten by a subsequent call to Scan.
https://golang.org/pkg/bufio/#Scanner.Bytes

This change increases memory usage, but prevents corruption.